### PR TITLE
video embed architecture

### DIFF
--- a/ADR/ml-video-embed.md
+++ b/ADR/ml-video-embed.md
@@ -1,0 +1,84 @@
+
+```mermaid
+flowchart TD
+    Cansiter1[(Canister 1)]
+    Cansiter2[(Canister 2)]
+    OffChainAgent[OffChain Agent]
+    Frontend[Frontend SSR]
+    GPU1[GPU 1]
+    GPU2[GPU 2]
+    BigQuery[(BigQuery)]
+    VectorDB[(VectorDB)]
+    QStash[[QStash]]
+
+    OffChainAgent --> OnChain
+    OffChainAgent ---> BigQuery
+
+    Frontend --[1]--> OffChainAgent
+
+    OffChainAgent --[2]--> QStash
+    QStash --[3(push/retries)]--> OffChainAgent
+    OffChainAgent --[4]--> FlyMLServer
+    OffChainAgent --[5]--> VectorDB
+
+    subgraph OnChain
+        Cansiter1
+        Cansiter2
+    end
+
+    subgraph FlyMLServer[Fly ML Server - autoscale]
+        GPU1
+        GPU2
+        GPU3
+    end
+```
+
+Pros:
+
+
+Cons:
+
+
+
+--------------------------------
+
+
+```mermaid
+flowchart TD
+    Cansiter1[(Canister 1)]
+    Cansiter2[(Canister 2)]
+    OffChainAgent[OffChain Agent]
+    Frontend[Frontend SSR]
+    GPU1[GPU 1]
+    GPU2[GPU 2]
+    BigQuery[(BigQuery)]
+    VectorDB[(VectorDB)]
+    Kafka[[Kafka]]
+
+    OffChainAgent --> OnChain
+    OffChainAgent ---> BigQuery
+
+    Frontend --[1]--> OffChainAgent
+
+    OffChainAgent --[2]--> Kafka
+    Kafka --[3(pull/<br>consumer group)]--> FlyMLServer
+    FlyMLServer --[4]--> VectorDB
+
+    subgraph OnChain
+        Cansiter1
+        Cansiter2
+    end
+
+    subgraph FlyMLServer[Fly ML Server - autoscale with Q-len]
+        GPU1
+        GPU2
+        GPU3
+    end
+```
+
+
+Pros:
+
+
+Cons:
+


### PR DESCRIPTION

```mermaid
flowchart TD
    Cansiter1[(Canister 1)]
    Cansiter2[(Canister 2)]
    OffChainAgent[OffChain Agent]
    Frontend[Frontend SSR]
    GPU1[GPU 1]
    GPU2[GPU 2]
    BigQuery[(BigQuery)]
    VectorDB[(VectorDB)]
    QStash[[QStash]]

    OffChainAgent --> OnChain
    OffChainAgent ---> BigQuery

    Frontend --[1]--> OffChainAgent

    OffChainAgent --[2]--> QStash
    QStash --[3(push/retries)]--> OffChainAgent
    OffChainAgent --[4]--> FlyMLServer
    OffChainAgent --[5]--> VectorDB

    subgraph OnChain
        Cansiter1
        Cansiter2
    end

    subgraph FlyMLServer[Fly ML Server - autoscale]
        GPU1
        GPU2
        GPU3
    end
```

Pros:

- simple design


Nuances:

- fly-proxy will still drop connections but upstash will retry and eventually put them in DLQ. Can run a job to clean up DLQ periodically.
- ML server needs ~5-10 secs for all the processes to start accepting requests. Meanwhile the call fails, so retry mechanism needs to be implemented in offchain.

--------------------------------


```mermaid
flowchart TD
    Cansiter1[(Canister 1)]
    Cansiter2[(Canister 2)]
    OffChainAgent[OffChain Agent]
    Frontend[Frontend SSR]
    GPU1[GPU 1]
    GPU2[GPU 2]
    BigQuery[(BigQuery)]
    VectorDB[(VectorDB)]
    Kafka[[Kafka]]

    OffChainAgent --> OnChain
    OffChainAgent ---> BigQuery

    Frontend --[1]--> OffChainAgent

    OffChainAgent --[2]--> Kafka
    Kafka --[3(pull/<br>consumer group)]--> FlyMLServer
    FlyMLServer --[4]--> VectorDB

    subgraph OnChain
        Cansiter1
        Cansiter2
    end

    subgraph FlyMLServer[Fly ML Server - autoscale with Q-len]
        GPU1
        GPU2
        GPU3
    end
```

Pros:

- Consumption at ML server's capacity

Nuances:

- Need to configure fly-autoscaler to read Kafka topic length and autoscale MLserver accordingly
- write out own retry logic and manage DLQ
- GPU time getting wasted with ingesting to VectorDB

---------------------


### Alternative to fly.io

- GKE/GCE GPU