### PR TITLE
feat: add helper function to convert payloads to string maps for noti…

### DIFF
--- a/src/events/types.rs
+++ b/src/events/types.rs
@@ -878,7 +878,7 @@ pub fn deserialize_event_payload(
 }
 
 #[test]
-fn test(){
+fn test_payload_to_string_map(){
     let payload = VideoUploadSuccessfulPayload{
         canister_id: Principal::from_text("mlj75-eyaaa-aaaaa-qbn5q-cai").unwrap(),
         post_id: 123,

--- a/src/events/types.rs
+++ b/src/events/types.rs
@@ -876,3 +876,83 @@ pub fn deserialize_event_payload(
         _ => Err(serde_json::Error::unknown_field(event_name, &[])),
     }
 }
+
+#[test]
+fn test(){
+    let payload = VideoUploadSuccessfulPayload{
+        canister_id: Principal::from_text("mlj75-eyaaa-aaaaa-qbn5q-cai").unwrap(),
+        post_id: 123,
+        publisher_user_id: Principal::from_text("mlj75-eyaaa-aaaaa-qbn5q-cai").unwrap(),
+        user_id: Principal::from_text("mlj75-eyaaa-aaaaa-qbn5q-cai").unwrap(),
+        display_name: None,
+        creator_category: "test".to_string(),
+        hashtag_count: 0,
+        is_nsfw: false,
+        is_hotor_not: false,
+        is_filter_used: false,
+        video_id: "test".to_string(),
+        country: None,
+    };
+
+    let notif_payload = SendNotificationReq {
+        notification: Some(NotificationPayload {
+            title: Some("test".to_string()),
+            body: Some("test".to_string()),
+            image: Some(
+                "https://yral.com/img/yral/android-chrome-384x384.png".to_string(),
+            ),
+        }),
+        data: Some(serde_json::to_value(payload_to_string_map(&payload)).unwrap()),
+        android: Some(AndroidConfig {
+            notification: Some(AndroidNotification {
+                icon: Some(
+                    "https://yral.com/img/yral/android-chrome-384x384.png".to_string(),
+                ),
+                image: Some(
+                    "https://yral.com/img/yral/android-chrome-384x384.png".to_string(),
+                ),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }),
+        webpush: Some(WebpushConfig {
+            fcm_options: Some(WebpushFcmOptions {
+                link: Some(format!(
+                    "https://yral.com/hot-or-not/{}/{}",
+                    payload.canister_id.to_text(),
+                    payload.post_id
+                )),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }),
+        apns: Some(ApnsConfig {
+            fcm_options: Some(ApnsFcmOptions {
+                image: Some(
+                    "https://yral.com/img/yral/android-chrome-384x384.png".to_string(),
+                ),
+                ..Default::default()
+            }),
+            payload: Some(json!({
+                "aps": {
+                    "alert": {
+                        "title": "test".to_string(),
+                        "body": "test".to_string(),
+                    },
+                    "sound": "default",
+                },
+                "url": format!("https://yral.com/hot-or-not/{}/{}", payload.canister_id.to_text(), payload.post_id)
+            })),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    
+    let stringed_payload = serde_json::to_string(&notif_payload).unwrap();
+
+    let deserialized_payload: SendNotificationReq = serde_json::from_str(&stringed_payload).unwrap();
+
+    let data = serde_json::from_value::<HashMap<String, String>>(deserialized_payload.data.unwrap()).unwrap();
+
+    println!("{:?}", data);
+}


### PR DESCRIPTION
data field only support {string: string} not arbitary json, hence there was a need to add a helper which converts the type into a HashMap<String, String>


source: https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#resource:-message