### PR TITLE
feat: Integrate LLM handler, Stable Audio, and WAN 2.2 for complete video-audio pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 [[package]]
 name = "alloydb-client"
 version = "0.1.0"
-source = "git+https://github.com/yral-dapp/yral-common?branch=master#d4f8f79800b6a683a3fb1fefc832a2034563eda1"
+source = "git+https://github.com/yral-dapp/yral-common?branch=videogen-audio-pipeline#169c669b925673d11f1fbef1951dd82b48d156d6"
 dependencies = [
  "google-cloud-alloydb-v1",
 ]
@@ -2038,6 +2038,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2468,7 +2491,7 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 [[package]]
 name = "global-constants"
 version = "0.1.0"
-source = "git+https://github.com/yral-dapp/yral-common?branch=master#d4f8f79800b6a683a3fb1fefc832a2034563eda1"
+source = "git+https://github.com/yral-dapp/yral-common?branch=videogen-audio-pipeline#169c669b925673d11f1fbef1951dd82b48d156d6"
 dependencies = [
  "candid",
  "num-bigint 0.4.6",
@@ -2915,7 +2938,7 @@ dependencies = [
 [[package]]
 name = "hon-worker-common"
 version = "0.1.0"
-source = "git+https://github.com/yral-dapp/yral-common?branch=master#d4f8f79800b6a683a3fb1fefc832a2034563eda1"
+source = "git+https://github.com/yral-dapp/yral-common?branch=videogen-audio-pipeline#169c669b925673d11f1fbef1951dd82b48d156d6"
 dependencies = [
  "candid",
  "global-constants",
@@ -2925,7 +2948,7 @@ dependencies = [
  "serde_with 3.14.0",
  "thiserror 2.0.12",
  "url",
- "yral-identity",
+ "yral-identity 0.1.0 (git+https://github.com/yral-dapp/yral-common?branch=videogen-audio-pipeline)",
 ]
 
 [[package]]
@@ -5041,6 +5064,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jiff"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "jpeg-decoder"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5457,11 +5504,12 @@ dependencies = [
 [[package]]
 name = "ml-feed-cache"
 version = "0.2.0"
-source = "git+https://github.com/yral-dapp/yral-common?branch=master#d4f8f79800b6a683a3fb1fefc832a2034563eda1"
+source = "git+https://github.com/yral-dapp/yral-common?branch=videogen-audio-pipeline#169c669b925673d11f1fbef1951dd82b48d156d6"
 dependencies = [
  "anyhow",
  "bb8",
  "bb8-redis",
+ "env_logger",
  "log",
  "redis 0.29.5",
  "redis-macros",
@@ -5754,7 +5802,7 @@ dependencies = [
  "videogen-common",
  "yral-canisters-client",
  "yral-canisters-common",
- "yral-identity",
+ "yral-identity 0.1.0 (git+https://github.com/yral-dapp/yral-common?branch=videogen-audio-pipeline)",
  "yral-metadata-client 0.1.0 (git+https://github.com/yral-dapp/yral-metadata.git)",
  "yral-metadata-types 0.1.0 (git+https://github.com/yral-dapp/yral-metadata?branch=master)",
  "yral-metrics",
@@ -6170,6 +6218,21 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
 ]
 
 [[package]]
@@ -7955,7 +8018,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 [[package]]
 name = "sns-validation"
 version = "0.1.0"
-source = "git+https://github.com/yral-dapp/yral-common?branch=master#d4f8f79800b6a683a3fb1fefc832a2034563eda1"
+source = "git+https://github.com/yral-dapp/yral-common?branch=videogen-audio-pipeline#169c669b925673d11f1fbef1951dd82b48d156d6"
 dependencies = [
  "candid",
  "humantime",
@@ -9244,7 +9307,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "videogen-common"
 version = "0.1.0"
-source = "git+https://github.com/yral-dapp/yral-common?branch=master#d4f8f79800b6a683a3fb1fefc832a2034563eda1"
+source = "git+https://github.com/yral-dapp/yral-common?branch=videogen-audio-pipeline#169c669b925673d11f1fbef1951dd82b48d156d6"
 dependencies = [
  "candid",
  "enum_dispatch",
@@ -9257,7 +9320,7 @@ dependencies = [
  "thiserror 1.0.69",
  "utoipa",
  "web-sys",
- "yral-identity",
+ "yral-identity 0.1.0 (git+https://github.com/yral-dapp/yral-common?branch=videogen-audio-pipeline)",
  "yral-types",
 ]
 
@@ -9862,7 +9925,7 @@ dependencies = [
 [[package]]
 name = "yral-canisters-client"
 version = "0.1.0"
-source = "git+https://github.com/yral-dapp/yral-common?branch=master#d4f8f79800b6a683a3fb1fefc832a2034563eda1"
+source = "git+https://github.com/yral-dapp/yral-common?branch=videogen-audio-pipeline#169c669b925673d11f1fbef1951dd82b48d156d6"
 dependencies = [
  "anyhow",
  "candid",
@@ -9882,7 +9945,7 @@ dependencies = [
 [[package]]
 name = "yral-canisters-common"
 version = "0.1.0"
-source = "git+https://github.com/yral-dapp/yral-common?branch=master#d4f8f79800b6a683a3fb1fefc832a2034563eda1"
+source = "git+https://github.com/yral-dapp/yral-common?branch=videogen-audio-pipeline#169c669b925673d11f1fbef1951dd82b48d156d6"
 dependencies = [
  "async-trait",
  "candid",
@@ -9904,10 +9967,11 @@ dependencies = [
  "serde_json",
  "sns-validation",
  "thiserror 2.0.12",
+ "tracing",
  "url",
  "web-time",
  "yral-canisters-client",
- "yral-identity",
+ "yral-identity 0.1.0 (git+https://github.com/yral-dapp/yral-common?branch=videogen-audio-pipeline)",
  "yral-metadata-client 0.1.0 (git+https://github.com/yral-dapp/yral-metadata?branch=master)",
  "yral-metadata-types 0.1.0 (git+https://github.com/yral-dapp/yral-metadata?branch=master)",
  "yral-pump-n-dump-common",
@@ -9919,6 +9983,18 @@ dependencies = [
 name = "yral-identity"
 version = "0.1.0"
 source = "git+https://github.com/yral-dapp/yral-common?branch=master#d4f8f79800b6a683a3fb1fefc832a2034563eda1"
+dependencies = [
+ "candid",
+ "ic-agent",
+ "serde",
+ "thiserror 2.0.12",
+ "web-time",
+]
+
+[[package]]
+name = "yral-identity"
+version = "0.1.0"
+source = "git+https://github.com/yral-dapp/yral-common?branch=videogen-audio-pipeline#169c669b925673d11f1fbef1951dd82b48d156d6"
 dependencies = [
  "candid",
  "ic-agent",
@@ -9937,7 +10013,7 @@ dependencies = [
  "ic-agent",
  "reqwest 0.12.22",
  "thiserror 1.0.69",
- "yral-identity",
+ "yral-identity 0.1.0 (git+https://github.com/yral-dapp/yral-common?branch=master)",
  "yral-metadata-types 0.1.0 (git+https://github.com/yral-dapp/yral-metadata?branch=master)",
 ]
 
@@ -9949,7 +10025,7 @@ dependencies = [
  "ic-agent",
  "reqwest 0.12.22",
  "thiserror 1.0.69",
- "yral-identity",
+ "yral-identity 0.1.0 (git+https://github.com/yral-dapp/yral-common?branch=master)",
  "yral-metadata-types 0.1.0 (git+https://github.com/yral-dapp/yral-metadata.git)",
 ]
 
@@ -9965,7 +10041,7 @@ dependencies = [
  "thiserror 1.0.69",
  "utoipa",
  "utoipa-swagger-ui",
- "yral-identity",
+ "yral-identity 0.1.0 (git+https://github.com/yral-dapp/yral-common?branch=master)",
 ]
 
 [[package]]
@@ -9979,13 +10055,13 @@ dependencies = [
  "thiserror 1.0.69",
  "utoipa",
  "utoipa-swagger-ui",
- "yral-identity",
+ "yral-identity 0.1.0 (git+https://github.com/yral-dapp/yral-common?branch=master)",
 ]
 
 [[package]]
 name = "yral-metrics"
 version = "0.1.0"
-source = "git+https://github.com/yral-dapp/yral-common?branch=master#d4f8f79800b6a683a3fb1fefc832a2034563eda1"
+source = "git+https://github.com/yral-dapp/yral-common?branch=videogen-audio-pipeline#169c669b925673d11f1fbef1951dd82b48d156d6"
 dependencies = [
  "candid",
  "log",
@@ -10000,20 +10076,20 @@ dependencies = [
 [[package]]
 name = "yral-pump-n-dump-common"
 version = "0.1.0"
-source = "git+https://github.com/yral-dapp/yral-common?branch=master#d4f8f79800b6a683a3fb1fefc832a2034563eda1"
+source = "git+https://github.com/yral-dapp/yral-common?branch=videogen-audio-pipeline#169c669b925673d11f1fbef1951dd82b48d156d6"
 dependencies = [
  "candid",
  "serde",
  "serde_json",
  "uuid",
  "yral-canisters-client",
- "yral-identity",
+ "yral-identity 0.1.0 (git+https://github.com/yral-dapp/yral-common?branch=videogen-audio-pipeline)",
 ]
 
 [[package]]
 name = "yral-qstash-types"
 version = "0.1.0"
-source = "git+https://github.com/yral-dapp/yral-common?branch=master#d4f8f79800b6a683a3fb1fefc832a2034563eda1"
+source = "git+https://github.com/yral-dapp/yral-common?branch=videogen-audio-pipeline#169c669b925673d11f1fbef1951dd82b48d156d6"
 dependencies = [
  "candid",
  "serde",
@@ -10031,7 +10107,7 @@ dependencies = [
 [[package]]
 name = "yral-types"
 version = "0.1.0"
-source = "git+https://github.com/yral-dapp/yral-common?branch=master#d4f8f79800b6a683a3fb1fefc832a2034563eda1"
+source = "git+https://github.com/yral-dapp/yral-common?branch=videogen-audio-pipeline#169c669b925673d11f1fbef1951dd82b48d156d6"
 dependencies = [
  "ic-agent",
  "k256",
@@ -10046,7 +10122,7 @@ dependencies = [
 [[package]]
 name = "yral-username-gen"
 version = "0.1.0"
-source = "git+https://github.com/yral-dapp/yral-common?branch=master#d4f8f79800b6a683a3fb1fefc832a2034563eda1"
+source = "git+https://github.com/yral-dapp/yral-common?branch=videogen-audio-pipeline#169c669b925673d11f1fbef1951dd82b48d156d6"
 dependencies = [
  "candid",
  "rand 0.9.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,21 +103,21 @@ tempfile = "3.8"
 
 # ===== YRAL-COMMON DEPENDENCIES =====
 # Remote (Git) - uncomment to use remote versions
-yral-canisters-client = { git = "https://github.com/yral-dapp/yral-common.git", branch = "master", features = [
+yral-canisters-client = { git = "https://github.com/yral-dapp/yral-common.git", branch = "videogen-audio-pipeline", features = [
     "full",
     "user-post-service",
 ] }
-yral-ml-feed-cache = { git = "https://github.com/yral-dapp/yral-common", branch = "master", package = "ml-feed-cache" }
-yral-alloydb-client = { git = "https://github.com/yral-dapp/yral-common", branch = "master", package = "alloydb-client" }
-yral-qstash-types = { git = "https://github.com/yral-dapp/yral-common.git", branch = "master" }
-yral-metrics = { git = "https://github.com/yral-dapp/yral-common", branch = "master" }
-videogen-common = { git = "https://github.com/yral-dapp/yral-common", branch = "master", features = [
+yral-ml-feed-cache = { git = "https://github.com/yral-dapp/yral-common", branch = "videogen-audio-pipeline", package = "ml-feed-cache" }
+yral-alloydb-client = { git = "https://github.com/yral-dapp/yral-common", branch = "videogen-audio-pipeline", package = "alloydb-client" }
+yral-qstash-types = { git = "https://github.com/yral-dapp/yral-common.git", branch = "videogen-audio-pipeline" }
+yral-metrics = { git = "https://github.com/yral-dapp/yral-common", branch = "videogen-audio-pipeline" }
+videogen-common = { git = "https://github.com/yral-dapp/yral-common", branch = "videogen-audio-pipeline", features = [
     "ic",
     "server",
 ] }
-yral-identity = { git = "https://github.com/yral-dapp/yral-common", branch = "master" }
-yral-canisters-common = { git = "https://github.com/yral-dapp/yral-common", branch = "master" }
-yral-types = { git = "https://github.com/yral-dapp/yral-common", branch = "master" }
+yral-identity = { git = "https://github.com/yral-dapp/yral-common", branch = "videogen-audio-pipeline" }
+yral-canisters-common = { git = "https://github.com/yral-dapp/yral-common", branch = "videogen-audio-pipeline" }
+yral-types = { git = "https://github.com/yral-dapp/yral-common", branch = "videogen-audio-pipeline" }
 
 
 # Local (Path) - uncomment to use local development versions

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -98,3 +98,13 @@ pub const VEO3_LOCATION: &str = "us-central1";
 // LumaLabs Constants
 pub const LUMALABS_API_URL: &str = "https://api.lumalabs.ai/dream-machine/v1";
 pub const LUMALABS_IMAGE_BUCKET: &str = "videogen_tmp_image_store";
+
+// WAN 2.2 Constants
+pub const RUNPOD_WAN2_2_T2V_ENDPOINT: &str = "wan-2-2-t2v-720";
+pub const RUNPOD_WAN2_2_I2V_ENDPOINT: &str = "wan-2-2-i2v-720";
+
+// LLM Handler Constants
+pub const LLM_HANDLER_URL: &str = "https://video-gen-llm-handler-router.fly.dev";
+
+// Stable Audio Constants
+pub const STABLE_AUDIO_URL: &str = "https://api.replicate.com/v1/models/stability-ai/stable-audio-2.5/predictions";

--- a/src/videogen/mod.rs
+++ b/src/videogen/mod.rs
@@ -1,6 +1,7 @@
 pub mod handlers;
 pub mod handlers_v2;
 pub mod models;
+pub mod orchestrator;
 pub mod qstash_callback;
 pub mod qstash_process;
 pub mod qstash_types;

--- a/src/videogen/models/llm_handler.rs
+++ b/src/videogen/models/llm_handler.rs
@@ -1,0 +1,90 @@
+use serde::{Deserialize, Serialize};
+use tracing::{error, info};
+use videogen_common::{VideoGenError, VideoGenInput};
+
+use crate::app_state::AppState;
+use crate::consts::LLM_HANDLER_URL;
+
+#[derive(Serialize)]
+struct LlmHandlerRequest {
+    prompt: String,
+}
+
+#[derive(Deserialize)]
+pub struct LlmHandlerResponse {
+    pub audio_description: String,
+    pub video_description: String,
+}
+
+pub async fn generate(
+    input: VideoGenInput,
+    _app_state: &AppState,
+) -> Result<LlmHandlerResponse, VideoGenError> {
+    let VideoGenInput::LlmHandler(model) = input else {
+        return Err(VideoGenError::InvalidInput(
+            "Only LlmHandler input is supported".to_string(),
+        ));
+    };
+
+    // Get JWT token from environment
+    let jwt_token = std::env::var("LLM_HANDLER_JWT_TOKEN").map_err(|_| {
+        error!("LLM_HANDLER_JWT_TOKEN not set in environment");
+        VideoGenError::AuthError
+    })?;
+
+    let client = reqwest::Client::new();
+
+    let request = LlmHandlerRequest {
+        prompt: model.user_prompt.clone(),
+    };
+
+    info!(
+        "Sending prompt to LLM handler: {}",
+        &model.user_prompt[..model.user_prompt.len().min(100)]
+    );
+
+    // Send request to LLM handler service
+    let response = client
+        .post(LLM_HANDLER_URL)
+        .header("Authorization", format!("Bearer {}", jwt_token))
+        .header("Content-Type", "application/json")
+        .json(&request)
+        .send()
+        .await
+        .map_err(|e| {
+            error!("Failed to send request to LLM handler: {}", e);
+            VideoGenError::NetworkError(format!("Failed to connect to LLM handler: {}", e))
+        })?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let error_text = response
+            .text()
+            .await
+            .unwrap_or_else(|_| "Unknown error".to_string());
+
+        error!("LLM handler returned error: {} - {}", status, error_text);
+
+        if status == 401 {
+            return Err(VideoGenError::AuthError);
+        }
+
+        return Err(VideoGenError::ProviderError(format!(
+            "LLM handler error: {} - {}",
+            status, error_text
+        )));
+    }
+
+    let llm_response: LlmHandlerResponse = response.json().await.map_err(|e| {
+        error!("Failed to parse LLM handler response: {}", e);
+        VideoGenError::ProviderError(format!("Invalid response from LLM handler: {}", e))
+    })?;
+
+    info!(
+        "LLM handler generated prompts - Audio: {} chars, Video: {} chars",
+        llm_response.audio_description.len(),
+        llm_response.video_description.len()
+    );
+
+    Ok(llm_response)
+}

--- a/src/videogen/models/mod.rs
+++ b/src/videogen/models/mod.rs
@@ -1,4 +1,7 @@
 pub mod inttest;
+pub mod llm_handler;
 pub mod lumalabs;
+pub mod stable_audio;
 pub mod veo3;
 pub mod veo3_fast;
+pub mod wan2_2;

--- a/src/videogen/models/stable_audio.rs
+++ b/src/videogen/models/stable_audio.rs
@@ -1,0 +1,236 @@
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+use tracing::{error, info};
+use videogen_common::{VideoGenError, VideoGenInput, VideoGenResponse};
+
+use crate::app_state::AppState;
+use crate::consts::STABLE_AUDIO_URL;
+
+#[derive(Serialize)]
+struct StableAudioRequest {
+    input: StableAudioInput,
+}
+
+#[derive(Serialize)]
+struct StableAudioInput {
+    prompt: String,
+    duration: u32, // Duration in seconds
+}
+
+#[derive(Deserialize)]
+struct StableAudioSubmitResponse {
+    id: String,
+    status: String,
+    urls: Option<StableAudioUrls>,
+    output: Option<String>, // Direct audio URL if available
+}
+
+#[derive(Deserialize)]
+struct StableAudioUrls {
+    get: String,
+    cancel: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct StableAudioStatusResponse {
+    id: String,
+    status: String,
+    output: Option<String>, // Audio URL when completed
+    error: Option<String>,
+    metrics: Option<StableAudioMetrics>,
+}
+
+#[derive(Deserialize)]
+struct StableAudioMetrics {
+    predict_time: Option<f64>,
+}
+
+pub async fn generate(
+    input: VideoGenInput,
+    _app_state: &AppState,
+) -> Result<VideoGenResponse, VideoGenError> {
+    let VideoGenInput::StableAudio(model) = input else {
+        return Err(VideoGenError::InvalidInput(
+            "Only StableAudio input is supported".to_string(),
+        ));
+    };
+
+    // Get API token from environment
+    let api_token = std::env::var("REPLICATE_API_TOKEN").map_err(|_| {
+        error!("REPLICATE_API_TOKEN not set in environment");
+        VideoGenError::AuthError
+    })?;
+
+    let client = reqwest::Client::new();
+
+    let request = StableAudioRequest {
+        input: StableAudioInput {
+            prompt: model.prompt.clone(),
+            duration: model.duration,
+        },
+    };
+
+    info!(
+        "Submitting audio generation for prompt: {} (duration: {}s)",
+        &model.prompt[..model.prompt.len().min(60)],
+        model.duration
+    );
+
+    // Submit job to Replicate
+    let response = client
+        .post(STABLE_AUDIO_URL)
+        .header("Authorization", format!("Bearer {}", api_token))
+        .header("Content-Type", "application/json")
+        .json(&request)
+        .timeout(Duration::from_secs(30))
+        .send()
+        .await
+        .map_err(|e| {
+            error!("Failed to submit audio generation job: {}", e);
+            VideoGenError::NetworkError(format!("Failed to connect to Stable Audio: {}", e))
+        })?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let error_text = response
+            .text()
+            .await
+            .unwrap_or_else(|_| "Unknown error".to_string());
+
+        error!("Stable Audio API error: {} - {}", status, error_text);
+
+        if status == 401 {
+            return Err(VideoGenError::AuthError);
+        }
+
+        return Err(VideoGenError::ProviderError(format!(
+            "Stable Audio error: {} - {}",
+            status, error_text
+        )));
+    }
+
+    let submit_response: StableAudioSubmitResponse = response.json().await.map_err(|e| {
+        error!("Failed to parse Stable Audio response: {}", e);
+        VideoGenError::ProviderError(format!("Invalid response from Stable Audio: {}", e))
+    })?;
+
+    info!(
+        "Audio generation job submitted with ID: {}",
+        submit_response.id
+    );
+
+    // Check if output is immediately available (for cached results)
+    if let Some(audio_url) = submit_response.output {
+        info!("Audio generation completed immediately (cached)");
+        return Ok(VideoGenResponse {
+            operation_id: submit_response.id,
+            video_url: audio_url, // Using video_url field for audio URL
+            provider: "stable_audio".to_string(),
+        });
+    }
+
+    // Extract status URL from the response
+    let status_url = submit_response
+        .urls
+        .ok_or_else(|| {
+            VideoGenError::ProviderError("No status URL provided in response".to_string())
+        })?
+        .get;
+
+    // Poll for completion
+    let audio_url = poll_for_completion(&status_url, &api_token).await?;
+
+    Ok(VideoGenResponse {
+        operation_id: submit_response.id,
+        video_url: audio_url, // Using video_url field for audio URL
+        provider: "stable_audio".to_string(),
+    })
+}
+
+async fn poll_for_completion(status_url: &str, api_token: &str) -> Result<String, VideoGenError> {
+    let client = reqwest::Client::new();
+
+    info!("Starting to poll for audio generation completion");
+
+    let max_attempts = 60; // 10 minutes with 10s intervals
+    let poll_interval = Duration::from_secs(10);
+
+    for attempt in 0..max_attempts {
+        let response = client
+            .get(status_url)
+            .header("Authorization", format!("Bearer {}", api_token))
+            .timeout(Duration::from_secs(30))
+            .send()
+            .await
+            .map_err(|e| {
+                error!("Failed to check audio generation status: {}", e);
+                VideoGenError::NetworkError(format!("Failed to check status: {}", e))
+            })?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(VideoGenError::ProviderError(format!(
+                "Failed to check status: {}",
+                error_text
+            )));
+        }
+
+        let status_response: StableAudioStatusResponse = response.json().await.map_err(|e| {
+            error!("Failed to parse status response: {}", e);
+            VideoGenError::ProviderError(format!("Failed to parse status response: {}", e))
+        })?;
+
+        match status_response.status.as_str() {
+            "succeeded" => {
+                if let Some(audio_url) = status_response.output {
+                    info!("Audio generation completed successfully");
+
+                    // Log metrics if available
+                    if let Some(metrics) = status_response.metrics {
+                        if let Some(predict_time) = metrics.predict_time {
+                            info!("Audio generation took {:.2}s", predict_time);
+                        }
+                    }
+
+                    return Ok(audio_url);
+                } else {
+                    return Err(VideoGenError::ProviderError(
+                        "Generation succeeded but no audio URL found".to_string(),
+                    ));
+                }
+            }
+            "failed" | "canceled" => {
+                let error = status_response
+                    .error
+                    .unwrap_or_else(|| format!("Job {}", status_response.status));
+                return Err(VideoGenError::ProviderError(format!(
+                    "Audio generation failed: {}",
+                    error
+                )));
+            }
+            "starting" | "processing" => {
+                if attempt > 0 && attempt % 3 == 0 {
+                    info!(
+                        "Audio generation still in progress... ({} seconds elapsed)",
+                        attempt * 10
+                    );
+                }
+            }
+            _ => {
+                // Unknown status, continue polling
+                info!("Unknown status: {}", status_response.status);
+            }
+        }
+
+        if attempt < max_attempts - 1 {
+            tokio::time::sleep(poll_interval).await;
+        }
+    }
+
+    Err(VideoGenError::ProviderError(
+        "Audio generation timed out after 10 minutes".to_string(),
+    ))
+}

--- a/src/videogen/models/wan2_2.rs
+++ b/src/videogen/models/wan2_2.rs
@@ -1,0 +1,302 @@
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+use tracing::{error, info};
+use videogen_common::{ImageData, VideoGenError, VideoGenInput, VideoGenResponse};
+
+use crate::app_state::AppState;
+use crate::consts::{RUNPOD_WAN2_2_I2V_ENDPOINT, RUNPOD_WAN2_2_T2V_ENDPOINT};
+use crate::utils::gcs::maybe_upload_image_to_gcs;
+
+#[derive(Serialize)]
+struct Wan22Request {
+    input: Wan22Input,
+}
+
+#[derive(Serialize)]
+struct Wan22Input {
+    prompt: String,
+
+    // Image URL for I2V mode
+    #[serde(skip_serializing_if = "Option::is_none")]
+    image: Option<String>,
+
+    // Updated parameters per requirements
+    size: String,                      // "720*1280"
+    duration: u32,                     // 5
+    num_inference_steps: u32,          // 40 (updated from 80)
+    guidance: u32,                     // 5
+    seed: i32,                         // -1
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    negative_prompt: Option<String>,   // ""
+
+    temperature: f32,                  // 0.7
+    flow_shift: u32,                   // 5
+    max_tokens: u32,                   // 256
+
+    enable_prompt_optimization: bool,  // true
+    enable_safety_checker: bool,       // true
+}
+
+#[derive(Deserialize)]
+struct Wan22SubmitResponse {
+    id: String,
+}
+
+#[derive(Deserialize)]
+struct Wan22StatusResponse {
+    status: String,
+    output: Option<Wan22Output>,
+    error: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct Wan22Output {
+    video_url: Option<String>,
+    url: Option<String>,
+    result: Option<String>,
+    video: Option<String>,
+
+    // Metadata
+    _width: Option<u32>,
+    _height: Option<u32>,
+    _duration: Option<f32>,
+    _seed: Option<u64>,
+    generation_time: Option<f32>,
+    cost: Option<f32>,
+}
+
+pub async fn generate(
+    input: VideoGenInput,
+    app_state: &AppState,
+) -> Result<VideoGenResponse, VideoGenError> {
+    let VideoGenInput::Wan22(mut model) = input else {
+        return Err(VideoGenError::InvalidInput(
+            "Only Wan22 input is supported".to_string(),
+        ));
+    };
+
+    let api_key = std::env::var("RUNPOD_API_KEY").map_err(|_| {
+        error!("RUNPOD_API_KEY not set in environment");
+        VideoGenError::AuthError
+    })?;
+
+    let client = reqwest::Client::new();
+
+    // Process image for I2V mode
+    let mut image_url = None;
+    if let Some(ref mut image_data) = model.image {
+        // Upload image to GCS if it's base64
+        let user_principal = "wan2_2_user"; // You may want to get this from the request
+        *image_data = maybe_upload_image_to_gcs(
+            app_state.gcs_client.clone(),
+            image_data.clone(),
+            user_principal,
+        )
+        .await
+        .map_err(|e| {
+            error!("Failed to upload image to GCS: {}", e);
+            VideoGenError::NetworkError(format!("Failed to upload image: {}", e))
+        })?;
+
+        // Extract URL from ImageData
+        image_url = match image_data {
+            ImageData::Url(url) => Some(url.clone()),
+            ImageData::Base64(_) => {
+                return Err(VideoGenError::InvalidInput(
+                    "Image should be URL after GCS upload".to_string(),
+                ))
+            }
+        };
+    }
+
+    // Determine endpoint based on mode
+    let endpoint = if model.is_i2v {
+        RUNPOD_WAN2_2_I2V_ENDPOINT
+    } else {
+        RUNPOD_WAN2_2_T2V_ENDPOINT
+    };
+
+    // Build request with updated parameters
+    let request = Wan22Request {
+        input: Wan22Input {
+            prompt: model.prompt.clone(),
+            image: image_url,
+            size: "720*1280".to_string(),
+            duration: 5,
+            num_inference_steps: 40, // Updated per requirements
+            guidance: 5,
+            seed: -1,
+            negative_prompt: Some("".to_string()),
+            temperature: 0.7,
+            flow_shift: 5,
+            max_tokens: 256,
+            enable_prompt_optimization: true,
+            enable_safety_checker: true,
+        },
+    };
+
+    // Submit job
+    let submit_url = format!("https://api.runpod.ai/v2/{}/run", endpoint);
+
+    info!(
+        "Submitting WAN 2.2 {} generation job for prompt: {}",
+        if model.is_i2v { "I2V" } else { "T2V" },
+        &model.prompt[..model.prompt.len().min(60)]
+    );
+
+    let response = client
+        .post(&submit_url)
+        .header("Authorization", format!("Bearer {}", api_key))
+        .header("Content-Type", "application/json")
+        .json(&request)
+        .timeout(Duration::from_secs(60))
+        .send()
+        .await
+        .map_err(|e| {
+            error!("Failed to submit job to RunPod: {}", e);
+            VideoGenError::NetworkError(format!("Failed to submit job: {}", e))
+        })?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let error_text = response
+            .text()
+            .await
+            .unwrap_or_else(|_| "Unknown error".to_string());
+
+        error!("RunPod API error: {} - {}", status, error_text);
+
+        if status == 401 {
+            return Err(VideoGenError::AuthError);
+        }
+
+        return Err(VideoGenError::ProviderError(format!(
+            "RunPod API error: {} - {}",
+            status, error_text
+        )));
+    }
+
+    let submit_response: Wan22SubmitResponse = response.json().await.map_err(|e| {
+        error!("Failed to parse RunPod response: {}", e);
+        VideoGenError::ProviderError(format!("Failed to parse submit response: {}", e))
+    })?;
+
+    info!("WAN 2.2 job submitted with ID: {}", submit_response.id);
+
+    // Poll for completion
+    let video_url = poll_for_completion(&submit_response.id, &api_key, endpoint).await?;
+
+    Ok(VideoGenResponse {
+        operation_id: submit_response.id,
+        video_url,
+        provider: "wan2_2".to_string(),
+    })
+}
+
+async fn poll_for_completion(
+    job_id: &str,
+    api_key: &str,
+    endpoint: &str,
+) -> Result<String, VideoGenError> {
+    let client = reqwest::Client::new();
+    let status_url = format!("https://api.runpod.ai/v2/{}/status/{}", endpoint, job_id);
+
+    info!("Starting to poll for completion of WAN 2.2 job: {}", job_id);
+
+    let max_attempts = 120; // 20 minutes with 10s intervals
+    let poll_interval = Duration::from_secs(10);
+
+    for attempt in 0..max_attempts {
+        let response = client
+            .get(&status_url)
+            .header("Authorization", format!("Bearer {}", api_key))
+            .timeout(Duration::from_secs(30))
+            .send()
+            .await
+            .map_err(|e| {
+                error!("Failed to check job status: {}", e);
+                VideoGenError::NetworkError(format!("Failed to check job status: {}", e))
+            })?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(VideoGenError::ProviderError(format!(
+                "Failed to check job status: {}",
+                error_text
+            )));
+        }
+
+        let status: Wan22StatusResponse = response.json().await.map_err(|e| {
+            error!("Failed to parse status response: {}", e);
+            VideoGenError::ProviderError(format!("Failed to parse status response: {}", e))
+        })?;
+
+        match status.status.as_str() {
+            "COMPLETED" => {
+                if let Some(output) = status.output {
+                    // Try different possible video URL fields
+                    let video_url = output
+                        .video_url
+                        .or(output.url)
+                        .or(output.result)
+                        .or(output.video);
+
+                    if let Some(url) = video_url {
+                        info!("WAN 2.2 video generation completed");
+
+                        // Log metadata if available
+                        if let Some(gen_time) = output.generation_time {
+                            info!("Generation time: {}s", gen_time);
+                        }
+                        if let Some(cost) = output.cost {
+                            info!("Cost: ${}", cost);
+                        }
+
+                        return Ok(url);
+                    } else {
+                        return Err(VideoGenError::ProviderError(
+                            "Generation completed but no video URL found".to_string(),
+                        ));
+                    }
+                } else {
+                    return Err(VideoGenError::ProviderError(
+                        "Generation completed but output not available".to_string(),
+                    ));
+                }
+            }
+            "FAILED" | "CANCELLED" | "TIMED_OUT" => {
+                let error = status
+                    .error
+                    .unwrap_or_else(|| format!("Job {}", status.status.to_lowercase()));
+                return Err(VideoGenError::ProviderError(format!(
+                    "Video generation failed: {}",
+                    error
+                )));
+            }
+            "IN_QUEUE" | "IN_PROGRESS" => {
+                if attempt > 0 && attempt % 6 == 0 {
+                    info!(
+                        "WAN 2.2 generation still in progress... ({} seconds elapsed)",
+                        attempt * 10
+                    );
+                }
+            }
+            _ => {
+                // Unknown status, continue polling
+                info!("Unknown status: {}", status.status);
+            }
+        }
+
+        if attempt < max_attempts - 1 {
+            tokio::time::sleep(poll_interval).await;
+        }
+    }
+
+    Err(VideoGenError::ProviderError(
+        "Video generation timed out after 20 minutes".to_string(),
+    ))
+}

--- a/src/videogen/orchestrator.rs
+++ b/src/videogen/orchestrator.rs
@@ -1,0 +1,122 @@
+use candid::Principal;
+use std::sync::Arc;
+use tracing::{error, info};
+use videogen_common::{
+    ImageData, VideoGenError, VideoGenInput, VideoGenResponse,
+    models::{LlmHandlerModel, StableAudioModel, Wan22Model},
+};
+
+use crate::app_state::AppState;
+use crate::videogen::models::{llm_handler, stable_audio, wan2_2};
+use crate::videogen::utils::stitch_video_audio_and_upload;
+
+/// Orchestrates the complete video generation pipeline with audio
+/// 1. Call LLM handler to generate prompts
+/// 2. Generate video with WAN 2.2
+/// 3. Generate audio with Stable Audio
+/// 4. Stitch video and audio together
+pub async fn generate_video_with_audio(
+    app_state: Arc<AppState>,
+    user_prompt: String,
+    input_image: Option<ImageData>,
+    user_principal: Principal,
+) -> Result<VideoGenResponse, VideoGenError> {
+    info!(
+        "Starting orchestrated video generation for user: {}",
+        user_principal
+    );
+
+    // Step 1: Call LLM Handler to generate prompts
+    info!("Step 1: Generating prompts with LLM handler");
+    let llm_input = VideoGenInput::LlmHandler(LlmHandlerModel {
+        user_prompt: user_prompt.clone(),
+    });
+
+    let llm_response = llm_handler::generate(llm_input, &app_state)
+        .await
+        .map_err(|e| {
+            error!("Failed to generate prompts: {}", e);
+            e
+        })?;
+
+    info!(
+        "Generated prompts - Video: {} chars, Audio: {} chars",
+        llm_response.video_description.len(),
+        llm_response.audio_description.len()
+    );
+
+    // Step 2: Generate video with WAN 2.2
+    info!("Step 2: Generating video with WAN 2.2");
+    let is_i2v = input_image.is_some();
+    let wan_input = VideoGenInput::Wan22(Wan22Model {
+        prompt: llm_response.video_description,
+        image: input_image,
+        is_i2v,
+    });
+
+    // Run video and audio generation in parallel
+    let video_future = wan2_2::generate(wan_input, &app_state);
+
+    // Step 3: Generate audio with Stable Audio (in parallel)
+    info!("Step 3: Generating audio with Stable Audio (in parallel)");
+    let audio_input = VideoGenInput::StableAudio(StableAudioModel {
+        prompt: llm_response.audio_description,
+        duration: 90, // Default duration
+    });
+
+    let audio_future = stable_audio::generate(audio_input, &app_state);
+
+    // Wait for both to complete
+    let (video_result, audio_result) = tokio::join!(video_future, audio_future);
+
+    let video_response = video_result.map_err(|e| {
+        error!("Failed to generate video: {}", e);
+        e
+    })?;
+
+    let audio_response = audio_result.map_err(|e| {
+        error!("Failed to generate audio: {}", e);
+        e
+    })?;
+
+    info!(
+        "Video generated: {}, Audio generated: {}",
+        video_response.video_url, audio_response.video_url
+    );
+
+    // Step 4: Stitch video and audio together
+    info!("Step 4: Stitching video and audio");
+    let stitched_url = stitch_video_audio_and_upload(
+        app_state.gcs_client.clone(),
+        &video_response.video_url,
+        &audio_response.video_url, // Using video_url field for audio URL
+        user_principal,
+        Some(format!(
+            "orchestrated_{}_{}",
+            video_response.operation_id,
+            chrono::Utc::now().timestamp_millis()
+        )),
+    )
+    .await
+    .map_err(|e| {
+        error!("Failed to stitch video and audio: {}", e);
+        e
+    })?;
+
+    info!("Successfully generated video with audio: {}", stitched_url);
+
+    Ok(VideoGenResponse {
+        operation_id: format!("{}_{}", video_response.operation_id, audio_response.operation_id),
+        video_url: stitched_url,
+        provider: "orchestrated_wan2_2_stable_audio".to_string(),
+    })
+}
+
+/// Simplified version that takes just a prompt and generates everything
+pub async fn generate_from_prompt(
+    app_state: Arc<AppState>,
+    user_prompt: String,
+    user_principal: Principal,
+) -> Result<VideoGenResponse, VideoGenError> {
+    generate_video_with_audio(app_state, user_prompt, None, user_principal).await
+}

--- a/src/videogen/qstash_process.rs
+++ b/src/videogen/qstash_process.rs
@@ -36,6 +36,24 @@ pub async fn process_video_generation(
         VideoGenInput::IntTest(_) => {
             crate::videogen::models::inttest::generate(request.input, &state).await
         }
+        VideoGenInput::TalkingHead(_) => {
+            // TalkingHead model not yet implemented in qstash processing
+            Err(VideoGenError::InvalidInput(
+                "TalkingHead model not supported in qstash processing".to_string(),
+            ))
+        }
+        VideoGenInput::Wan22(_) => {
+            crate::videogen::models::wan2_2::generate(request.input, &state).await
+        }
+        VideoGenInput::LlmHandler(_) => {
+            // LLM Handler returns a different response type, not directly usable here
+            Err(VideoGenError::InvalidInput(
+                "LLM Handler should not be processed through qstash".to_string(),
+            ))
+        }
+        VideoGenInput::StableAudio(_) => {
+            crate::videogen::models::stable_audio::generate(request.input, &state).await
+        }
     };
 
     // Prepare callback data

--- a/src/videogen/router.rs
+++ b/src/videogen/router.rs
@@ -19,5 +19,6 @@ pub fn videogen_router_v2<S>(state: Arc<AppState>) -> OpenApiRouter<S> {
         .routes(routes!(handlers_v2::get_providers))
         .routes(routes!(handlers_v2::get_providers_all))
         .routes(routes!(handlers_v2::generate_video_with_identity_v2))
+        .routes(routes!(handlers_v2::generate_video_with_audio))
         .with_state(state)
 }


### PR DESCRIPTION
## Summary
- Integrates LLM handler for prompt generation with JWT authentication
- Adds Stable Audio integration via Replicate API for background music/SFX
- Implements WAN 2.2 model with both T2V and I2V support
- Creates orchestrator that combines all services into a complete pipeline
- Adds new `/v2/generate-with-audio` API endpoint
- Leverages existing FFmpeg video/audio stitching functionality

## Implementation Details

### New Services:
1. **LLM Handler** - Generates optimized video and audio prompts from user input
2. **Stable Audio** - Creates background music/sound effects
3. **WAN 2.2** - Video generation with T2V/I2V support (updated parameters)
4. **Orchestrator** - Coordinates the complete pipeline

### API Flow:
1. User sends prompt to `/v2/generate-with-audio`
2. LLM handler generates video and audio descriptions
3. Video and audio are generated in parallel
4. FFmpeg stitches them together
5. Final video is uploaded to GCS

## Required Environment Variables
- `LLM_HANDLER_JWT_TOKEN` - JWT token for LLM handler authentication
- `REPLICATE_API_TOKEN` - Token for Replicate/Stable Audio API
- `RUNPOD_API_KEY` - Token for RunPod/WAN 2.2 API

## Dependencies
- Updated yral-common dependencies to use `videogen-audio-pipeline` branch
- This branch contains the model definitions for the new services

## Testing
Run `cargo check` - compiles successfully with only expected deprecation warnings