### PR TITLE
chore: migrate report-approved to new GCP project

### DIFF
--- a/src/offchain_service.rs
+++ b/src/offchain_service.rs
@@ -178,7 +178,7 @@ pub async fn report_approved_handler(
 
     let mut validation = jsonwebtoken::Validation::new(jsonwebtoken::Algorithm::RS256);
     validation.set_issuer(&["chat@system.gserviceaccount.com"]);
-    validation.set_audience(&["82502260393"]);
+    validation.set_audience(&["1035262663512"]);
 
     let mut valid = false;
 


### PR DESCRIPTION
## Summary
- Update Google Chat app project number for JWT validation
- Old project: `82502260393`
- New project: `1035262663512` (offchain-agent-reports)

## Changes
- `src/offchain_service.rs`: Update `set_audience` in JWT validation

## Test plan
- [ ] Deploy to staging
- [ ] Test report approval flow in Google Chat